### PR TITLE
devlink port splitting support for 1x100G CXP NIC

### DIFF
--- a/src/nfp_devlink.c
+++ b/src/nfp_devlink.c
@@ -103,6 +103,7 @@ nfp_devlink_port_split(struct devlink *devlink, unsigned int port_index,
 {
 	struct nfp_pf *pf = devlink_priv(devlink);
 	struct nfp_eth_table_port eth_port;
+	unsigned int lanes;
 	int ret;
 
 	if (count < 2)
@@ -121,8 +122,12 @@ nfp_devlink_port_split(struct devlink *devlink, unsigned int port_index,
 		goto out;
 	}
 
-	ret = nfp_devlink_set_lanes(pf, eth_port.index,
-				    eth_port.port_lanes / count);
+	/* Special case the 100G CXP -> 2x40G split */
+	lanes = eth_port.port_lanes / count;
+	if (eth_port.lanes == 10 && count == 2)
+		lanes = 8 / count;
+
+	ret = nfp_devlink_set_lanes(pf, eth_port.index, lanes);
 out:
 	mutex_unlock(&pf->lock);
 
@@ -139,6 +144,7 @@ nfp_devlink_port_unsplit(struct devlink *devlink, unsigned int port_index,
 {
 	struct nfp_pf *pf = devlink_priv(devlink);
 	struct nfp_eth_table_port eth_port;
+	unsigned int lanes;
 	int ret;
 
 	mutex_lock(&pf->lock);
@@ -154,7 +160,12 @@ nfp_devlink_port_unsplit(struct devlink *devlink, unsigned int port_index,
 		goto out;
 	}
 
-	ret = nfp_devlink_set_lanes(pf, eth_port.index, eth_port.port_lanes);
+	/* Special case the 100G CXP -> 2x40G unsplit */
+	lanes = eth_port.port_lanes;
+	if (eth_port.port_lanes == 8)
+		lanes = 10;
+
+	ret = nfp_devlink_set_lanes(pf, eth_port.index, lanes);
 out:
 	mutex_unlock(&pf->lock);
 


### PR DESCRIPTION
## Overview

This PR makes it possible to use devlink to split the 100G CXP Netronome into two 40G interfaces. Currently when you ask for 2 interfaces, the math in src/nfp_devlink.c:nfp_devlink_port_split calculates that you want 5 lanes per port because for some reason eth_port.port_lanes=10 (shouldn't this be 12 for CXP?). What we really want when asking for 2 breakout interfaces is 4 lanes per port. This commit makes that happen by calculating based on 8 lanes if 10 are present.

I have tested this on Fedora 28 running kernel 4.18.11 with a loopback device plugged into the CXP port of the Netronome. The ports can now be broken out into 2x40 via `devlink port split pci/<nfp-path>/0 count 2`. Upon reinserting the nfp kernel module both breakout ports show up and show that the link has a carrier. The changes are also reflected in `nfp-phymod`

On my system I have soft linked 
```
nic_AMDA0078-0011_2x40.nffw -> nic_AMDA0058-0011_2x40.nffw
```
When the CXP port is split into two, this is the firmware that gets loaded by the nfp kernel module. When it gets unsplit back to one port, the `nic_AMDA0078-0011_1x100.nffw` firmware is loaded by nfp.

## Potential Issues
Just looking for a lane count of 10 for split and 8 for unsplit is pretty hacky. I can't think of an interface type off hand that this would cause issues for, as all the other Netronome cards are in the [Q]SFP[+,28] family and those max out at 4 lanes per interface. However, it's very possible I am conflating PHY lanes with some other sort lane is that is actually in play here. This would explain why the CXP presents 10 lanes when I would expect 12 for that type of interface.

If there are any suggestions or pointers on how to implement this better, perhaps by incorporating device type into the logic, I am happy to implement and test them.